### PR TITLE
Ask people to list non-consensus dependencies in their explainers.

### DIFF
--- a/explainers/index.md
+++ b/explainers/index.md
@@ -54,7 +54,7 @@ you should always try to keep your explainer as brief and easy to read as possib
 - Keep it as brief and "skimmable" as you possibly can.
   - Writing succinctly is harder than writing at length. You might need to write a first draft, and then make one or more editing passes to cut down word count. This is a time investment, but will save time and energy for your readers.
   - Use bulleted lists where possible.
-  - Draw attention to key points using **bold**. 
+  - Draw attention to key points using **bold**.
   - Keep your paragraphs and sentences short. Paragraphs should contain one idea only, and likely shouldn't be more than a couple of sentences. Break up large paragraphs as much as possible.
 - Keep the language as simple as possible.
   - Not all readers will always be fluent English speakers.

--- a/explainers/index.md
+++ b/explainers/index.md
@@ -22,6 +22,7 @@ As your work progresses, the explainer can help facilitate multi-stakeholder dis
 - the proposed approach to solving the problem;
 - the way the proposed solution may be used in practice to address the intended use cases, via example code;
 - any other venues (such as mailing list, pull requests or issue threads external to the location of the explainer) where the reader may catch up on discussions regarding the proposed feature or features;
+- what other proposed features the proposed solution depends on, if any;
 - the alternatives which have already been considered and why they were not chosen;
 - accessibility, security and privacy implications which have been considered as part of the design process.
 

--- a/explainers/template.md
+++ b/explainers/template.md
@@ -99,10 +99,11 @@ in which case you should link to any active discussion threads.]
 
 [etc.]
 
-## Non-consensus dependencies
+## Dependencies on non-stable features
 
 [If your proposed solution depends on any other features that haven't been either implemented by
-multiple browser engines or adopted by a standards working group, list them here.]
+multiple browser engines or adopted by a standards working group (that is, not just a W3C community
+group), list them here.]
 
 ## Considered alternatives
 

--- a/explainers/template.md
+++ b/explainers/template.md
@@ -36,7 +36,7 @@ enumerate them here. This section may be fleshed out as your design progresses a
 ## User research
 
 [If any user research has been conducted to inform the design choices presented
-discuss the process and findings. 
+discuss the process and findings.
 We strongly encourage that API designers consider conducting user research to
 verify that their designs meet user needs and iterate on them,
 though we understand this is not always feasible.]

--- a/explainers/template.md
+++ b/explainers/template.md
@@ -99,6 +99,11 @@ in which case you should link to any active discussion threads.]
 
 [etc.]
 
+## Non-consensus dependencies
+
+[If your proposed solution depends on any other features that haven't been either implemented by
+multiple browser engines or adopted by a standards working group, list them here.]
+
 ## Considered alternatives
 
 [This should include as many alternatives as you can,


### PR DESCRIPTION
Both @hober and @torgo have complained about Chromium shipping features that depend on other non-consensus features. While Chromium's likely to keep doing this, we can pretty easily list the non-consensus dependencies in the explainer so that y'all don't have to re-discover them. The other benefit of listing these is that it could prompt us to find solutions that don't have as many dependencies, but I couldn't find a place in this repository to cleanly fit in that explanation. Suggestions are welcome.