### PR TITLE
appointed by the Team, no longer Tim

### DIFF
--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -3,7 +3,7 @@
   <h1 class="display-3">W3C TAG</h1>
 
   <p class="lead">
-    The <strong>Technical Architecture Group</strong> documents the architecture of the World Wide Web and assists the community in interpreting it. It is composed of engineers both elected by the membership of the <a href="https://www.w3.org/">W3C</a> and appointed by Tim Berners-Lee, working to safeguard and extend the Web through coordination, collaboration, and review.
+    The <strong>Technical Architecture Group</strong> documents the architecture of the World Wide Web and assists the community in interpreting it. It is composed of engineers both elected by the membership of the <a href="https://www.w3.org/">W3C</a> and <a href="https://www.w3.org/policies/process/#TAG-appointments">appointed by the W3C Team</a>, working to safeguard and extend the Web through coordination, collaboration, and review.
   </p>
   <a class="btn btn-primary" href="https://www.w3.org/2001/tag/" role="button">Learn More About Us</a>
   </div>


### PR DESCRIPTION
fix banner to note appointment by W3C Team per process (linked), rather than Tim Berners-Lee.