### PR TITLE
Update history with 2024 election results, and fix some older data.

### DIFF
--- a/history/index.md
+++ b/history/index.md
@@ -51,10 +51,12 @@ Found a mistake? [Correct it with a pull request!](https://github.com/w3ctag/tag
 - [TAG election results (Dec 2022)](https://www.w3.org/news/2022/w3c-advisory-committee-elects-technical-architecture-group-11/)
 - [TAG election results (Dec 2023)](https://www.w3.org/news/2023/w3c-advisory-committee-elects-technical-architecture-group/)
 - [Detailed TAG election results (Dec 2023)](https://lists.w3.org/Archives/Member/w3c-ac-members/2023OctDec/0059.html) *(Member-only)*
+- [TAG election results (Dec 2024)](https://www.w3.org/news/2024/w3c-advisory-committee-elects-technical-architecture-group/)
 
 ### Director appointments
 
 - [News Release: World Wide Web Consortium Forms Technical Architecture Group (2001)](https://lists.w3.org/Archives/Public/www-tag/2001Dec/0003)
+- [Director appointment (Dec 2003)](https://lists.w3.org/Archives/Member/w3c-ac-members/2003OctDec/0038.html) *(Member-only)*
 - [Vincent Quint Appointed to TAG (Dec 2004)](https://lists.w3.org/Archives/Member/w3c-ac-members/2004OctDec/0045.html) *(Member-only)*
 - [Director appointments (Nov 2005)](https://lists.w3.org/Archives/Member/w3c-ac-members/2005OctDec/0023.html) *(Member-only)*
 - [Stuart Williams appointed to TAG (Nov 2006)](https://lists.w3.org/Archives/Member/w3c-ac-members/2006OctDec/0049.html) *(Member-only)*

--- a/history/members.json
+++ b/history/members.json
@@ -34,7 +34,7 @@
 			},
 			{
 				"start": "2004-02-01",
-				"end": "2005-01-31",
+				"end": "2006-01-31",
 				"type": "appointed"
 			},
 			{
@@ -499,6 +499,11 @@
 				"end": "2013-05-17",
 				"type": "elected",
 				"resigned": true
+			},
+			{
+				"start": "2025-02-01",
+				"end": "2027-01-31",
+				"type": "elected"
 			}
 		]
 	},
@@ -643,6 +648,11 @@
 				"start": "2023-02-01",
 				"end": "2025-01-31",
 				"type": "appointed"
+			},
+			{
+				"start": "2025-02-01",
+				"end": "2027-01-31",
+				"type": "elected"
 			}
 		]
 	},
@@ -859,6 +869,26 @@
 				"start": "2024-07-15",
 				"end": "2026-01-31",
 				"type": "appointed"
+			}
+		]
+	},
+	{
+		"name": "Sarven Capadisli",
+		"term": [
+			{
+				"start": "2025-02-01",
+				"end": "2027-01-31",
+				"type": "elected"
+			}
+		]
+	},
+	{
+		"name": "Xiaocheng Hu",
+		"term": [
+			{
+				"start": "2025-02-01",
+				"end": "2027-01-31",
+				"type": "elected"
 			}
 		]
 	}


### PR DESCRIPTION
This change:
* adds the December 2024 election results
* fixes a 1 year gap for Dan Connolly that appears to be a typo
* adds one additional old citation