### PR TITLE
Recommend that Explainers use Markdown or similar.

### DIFF
--- a/explainers/index.md
+++ b/explainers/index.md
@@ -137,7 +137,7 @@ You should host your explainer as HTML at a stable, readable URL,
 ideally next to where the specification is expected to land.
 Use a source format like Markdown
 that makes it easy for reviewers to link directly to sections inside the document.
-It's fine to use a host like Github that automatically renders Markdown.
+It's fine to use a host like GitHub that automatically renders Markdown.
 
 ----
 

--- a/explainers/index.md
+++ b/explainers/index.md
@@ -135,8 +135,9 @@ or your [references and acknowledgements](https://github.com/w3ctag/tag.w3.org/b
 
 You should host your explainer as HTML at a stable, readable URL,
 ideally next to where the specification is expected to land.
-Use a source format like Markdown
-that makes it easy for reviewers to link directly to sections inside the document.
+Use a format
+that makes it easy for reviewers to link directly to sections inside the document,
+like Markdown or HTML.
 It's fine to use a host like GitHub that automatically renders Markdown.
 
 ----

--- a/explainers/index.md
+++ b/explainers/index.md
@@ -131,6 +131,14 @@ Link to all prior art in either
 your [considered alternatives](https://github.com/w3ctag/tag.w3.org/blob/main/explainers/template.md#considered-alternatives) section
 or your [references and acknowledgements](https://github.com/w3ctag/tag.w3.org/blob/main/explainers/template.md#references--acknowledgements).
 
+### Enable Easy Deep Linking
+
+You should host your explainer as HTML at a stable, readable URL,
+ideally next to where the specification is expected to land.
+Use a source format like Markdown
+that makes it easy for reviewers to link directly to sections inside the document.
+It's fine to use a host like Github that automatically renders Markdown.
+
 ----
 
 By following these guidelines, you can create clear, concise, and accessible explainers that effectively communicate your proposed web standards specifications for W3C TAG review.


### PR DESCRIPTION
This recommendation comes from w3ctag/tag.w3.org#39, but I rephrased it.

Fixes w3ctag/explainers#14.