### PR TITLE
Replace "considered alternatives" with "alternatives considered".

### DIFF
--- a/explainers/index.md
+++ b/explainers/index.md
@@ -28,7 +28,7 @@ it should contain the following key components:
    Explain the proposed solution or approach to addressing the identified problem.
 1. Practical Use Cases:
    Show example pieces of code that use the proposed solution to solve the user-facing problems.
-1. Considered Alternatives:
+1. Alternatives Considered:
    Describe other ways the problem might be solved and why you prefer your proposal.
 1. Accessibility, Security, and Privacy Considerations:
    Highlight any accessibility, security, and privacy implications that have been taken into account

--- a/explainers/template.md
+++ b/explainers/template.md
@@ -82,7 +82,7 @@ group), list them here.]
 
 [etc.]
 
-## Considered alternatives
+## Alternatives considered
 
 [This should include as many alternatives as you can,
 from high level architectural decisions down to alternative naming choices.]


### PR DESCRIPTION
@chrishtr suggested this in https://github.com/w3ctag/tag.w3.org/pull/39#discussion_r1270888018. "alternatives considered" seems to be about twice as common on the web, and it's what I tend to assume the section will be called, but I can see a grammatical argument against it, so I don't personally feel strongly.