### PR TITLE
Remove "for TAG Review" from title

### DIFF
--- a/explainers/index.md
+++ b/explainers/index.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Writing Effective Explainers for W3C TAG Review
+title: Writing Effective Explainers
 ---
 
 ## Participate


### PR DESCRIPTION
This document should not be grounded in a presumption that explainers only exist to appease the TAG.  An explainer provides critical information for a much wider audience than one specific star chamber.